### PR TITLE
Feat+: 메인 페이지 플랜 리스트 추가

### DIFF
--- a/src/common/layout/Header.tsx
+++ b/src/common/layout/Header.tsx
@@ -97,16 +97,16 @@ span:nth-of-type(1).active {
 const Header = () => {
 
     const [showMenu, setShowMenu] = useState(false);
+    console.log({showMenu})
     const onClickHamberger = () => {
         setShowMenu(!showMenu);
-
     }
 
     return (
         <HeaderWrapper>
             <HeaderBar>
                 <Button onClick={onClickHamberger}>
-                {[...Array(3)].map((n, index) => <span className={showMenu ? 'active' : ''}></span>)}
+                {[...Array(3)].map((n, index) => <span key={`bar-${index}`} className={showMenu ? 'active' : ''}></span>)}
                 </Button>
             </HeaderBar>
             <Draw className={showMenu ? 'active' : ''}>

--- a/src/common/layout/Header.tsx
+++ b/src/common/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { ROUTES } from 'constants/global';
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const navMenus = [
@@ -90,8 +90,6 @@ span:nth-of-type(1).active {
     -webkit-transform : translateY(-3px) rotate(45deg);
     transform : translateY(-3px) rotate(45deg);
   }
-
-
 `
 
 const Header = () => {
@@ -112,7 +110,7 @@ const Header = () => {
             <Draw className={showMenu ? 'active' : ''}>
                 <ul>
                     {navMenus.map((menu) => (
-                        <Link to={menu.url} key={menu.url}>
+                        <Link onClick={()=>{setShowMenu(false)}} to={menu.url} key={menu.url}>
                             <li>{menu.name}</li>
                         </Link>
                     ))}

--- a/src/common/layout/Layout.tsx
+++ b/src/common/layout/Layout.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
     width: 100%;
     max-width: 420px;
-    height: 100vh;
+    min-height: 100vh;
     background-color: white;
     margin: 0 auto;
 `

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,14 +1,23 @@
-import axios from "axios";
+import { PlanList, plan } from "pages/plans/PlanList";
+import { useState } from "react";
+
+/* FIXME 더미데이터*/
+const test = Array(50).fill(undefined).map((v, i)=>{
+	return {
+		id: i,
+		name: `테스트 플랜 ${i}번`,
+		creator: `작성자${i}`,
+		created: new Date().getTimezoneOffset,
+		hashtag: '갓생,영어공부,취준',
+		memberCount: Math.floor(Math.random() * 10),
+		status: Math.floor(Math.random() * 2)
+	}
+})
 
 const MainPage = () => {
 
-	const test = async()=> {
-		const res = axios.get('https://9490-14-7-11-24.ngrok-free.app/plans')
-	}
-
-
 	return <>
-		<button onClick={test}>누르거랑</button>
+		<PlanList plans={test} />
 	</>;
 }
 

--- a/src/pages/plans/PlanList.tsx
+++ b/src/pages/plans/PlanList.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+export type plan = {
+    id: number,
+    name: string,
+    creator: string,
+    created: any,
+    hashtag: string,
+    memberCount: number,
+    status: number
+}
+
+const planStatus = {
+    recruiting: 0,
+    recruitingEnd: 1,
+    end: 2
+
+}
+const getPlanStatName = (status: number) => {
+    console.log(status)
+    switch (status) {
+        case planStatus.recruiting:
+            return '모집중';
+        case planStatus.recruitingEnd:
+            return '모집마감';
+        case planStatus.end:
+            return '종료';
+        default:
+            return ''
+    }
+
+}
+const Ul = styled.ul`
+    width: 100%;
+    padding: 20px 0;
+`
+const Li = styled.li`
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    width: 100%;
+    height: 70px;
+    border: 2px solid #ddd;
+    border-radius: 10px;
+    margin-bottom: 10px;
+    align-items: center;
+    cursor: pointer;
+    padding: 15px 10px;
+    &:hover {
+        transition: all 0.2s ease;
+        -webkit-transform: translateY(-5px);
+        transform: translateY(-5px);
+    }
+    .plan-info {
+        width: 100%;
+        display: flex;
+        justify-conten: left;
+        .plan-name {
+            font-weight: bold;
+        }
+        .status {
+            margin-left: auto;
+            font-size: 12px;
+            color: #FFE135;
+        }
+    }
+    .hashtag-list {
+        display: flex;
+        width: 100%;
+        flex-wrap: wrap;
+        .hashtag {
+            display: flex;
+            align-items: center;
+            padding: 6px;
+            border-radius: 10px;
+            font-size: 12px;
+            color: #808080;
+            margin-right: 4px;
+        }
+    }
+`
+
+const MoreButton = styled.button`
+    dispaly: flex;
+    width: 100%;
+    height: 60px;
+    color: #FFE135;
+    font-weight: bold;
+    background-color:white;
+    border: 3px solid #FFE135;
+    border-radius: 10px;
+    cursor: pointer;
+`
+
+const PlanItem = (props: { plan: plan }) => {
+    const { name, created, creator, hashtag, status } = props.plan;
+    return (
+        <Li>
+            <div className="plan-info">
+                <p className="plan-name">{name}</p>
+                <p className="status">{getPlanStatName(status)}</p>
+
+            </div>
+            <ul className="hashtag-list">
+                {hashtag.split(',').map((tag) => <li key={tag} className="hashtag"><span>#{tag}</span></li>)}
+            </ul>
+        </Li>
+    )
+}
+export const PlanList = (props: { plans: plan[] }) => {
+
+    const { plans } = props;
+    const pageSize = 10;
+    const [pageNum, setPageNum] = useState(1);
+    const [list, setList] = useState<plan[]>(plans?.slice(0, pageNum * pageSize));
+
+    useEffect(() => {
+        if (pageNum * pageSize < plans.length) {
+            setList(plans?.slice(0, pageNum * pageSize))
+        } else {
+            alert('더 이상 목록이 없습니다')
+        }
+    }, [pageNum])
+    return (
+        <>
+            <h3>플랜 목록</h3>
+            <Ul>
+                {list.map((plan) => {
+                    return <PlanItem key={plan.id} plan={plan} />
+                })}
+            </Ul>
+            {pageNum * pageSize === plans.length - 1 ? '' : <MoreButton onClick={() => {
+                setPageNum(pageNum + 1);
+                console.log(pageNum)
+            }}>더보기</MoreButton>}
+        </>
+    )
+}


### PR DESCRIPTION
# 공통
- 햄버거 버튼 눌러서 나오는 우측 날개의 링크 버튼을 클릭해 이동했을 때 날개가 자동으로 닫히도록 수정
- 바디 부분의 높이를 100vh 고정에서 최소 높이 100vh으로 수정

# 메인 페이지
- 플랜 컴포넌트, 플랜 리스트 컴포넌트 추가
- 더보기 버튼 추가(추후 스크롤 이벤트로 대체 예정)